### PR TITLE
Add CI pipelines documentation and update workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,23 +11,20 @@ permissions:
   packages: read
   actions: read
 
-env:
-  CI_PROJECT_DIR: ${{ github.workspace }}
-
 jobs:
   build:
     name: build_${{ matrix.project }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/teufelaudio/myndfirmware:latest
+      image: ghcr.io/${{ github.repository_owner }}/myndfirmware:latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - project: Mynd
-            buildTargets: "mynd-update-firmware-mcu mynd-factory-update-firmware-mcu"
           - project: MyndBootloader
             buildTargets: "mynd-bootloader"
+          - project: Mynd
+            buildTargets: "mynd-update-firmware-mcu mynd-factory-update-firmware-mcu"
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v4
@@ -40,14 +37,14 @@ jobs:
           TFL_BUILD_TARGETS: ${{ matrix.buildTargets }}
           TFL_CMAKE_TOOLCHAIN_PREFIX: /usr/local
           TFL_CMAKE_BUILD_TYPE: Release
-          TFL_PROJECT_DIR: ${{ env.CI_PROJECT_DIR }}
-        run: ${CI_PROJECT_DIR}/support/scripts/cicd/shell/build_artifacts.sh
+          TFL_PROJECT_DIR: ${{ github.workspace }}
+        run: ${{ github.workspace }}/support/scripts/cicd/shell/build_artifacts.sh
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: build_${{ matrix.project }}
-          path: ${{ env.CI_PROJECT_DIR }}/build/Projects/${{ matrix.project }}
+          path: ${{ github.workspace }}/build/Projects/${{ matrix.project }}
           if-no-files-found: error
       - name: Upload CMake logs (on failure)
         if: failure()
@@ -55,7 +52,7 @@ jobs:
         with:
           name: cmake-logs_${{ matrix.project }}
           path: |
-            ${{ env.CI_PROJECT_DIR }}/build/CMakeFiles/CMakeOutput.log
-            ${{ env.CI_PROJECT_DIR }}/build/CMakeFiles/CMakeError.log
+            ${{ github.workspace }}/build/CMakeFiles/CMakeOutput.log
+            ${{ github.workspace }}/build/CMakeFiles/CMakeError.log
           if-no-files-found: ignore
           retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,7 @@ jobs:
     name: build_${{ matrix.project }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jomosa24/myndfirmware:latest
-      options: --platform linux/amd64
-      credentials:
-        username: ${{ secrets.GHCR_USER }}
-        password: ${{ secrets.GHCR_TOKEN }}
+      image: ghcr.io/teufelaudio/myndfirmware:latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+name: Build and Publish Docker Image for Mynd Build Env
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and push myndfirmware:latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build local image myndfirmware:latest
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: support/docker-build/docker-config/Dockerfile
+          push: false
+          load: true
+          tags: myndfirmware:latest
+
+      - name: Push to GHCR
+        run: |
+          docker tag myndfirmware:latest ghcr.io/${{ github.repository_owner }}/myndfirmware:latest
+          docker push ghcr.io/${{ github.repository_owner }}/myndfirmware:latest
+

--- a/README.md
+++ b/README.md
@@ -22,3 +22,23 @@ make mynd-update-firmware-mcu
    - `keys`             - Keys to sign firmware update file (Only for tests! They are not used.)
    - `scripts`          - Helper scripts for build and CI/CD
    - `svd`              - Hardware description file - internal registers outline
+
+
+   ## CI Pipelines Usage
+
+   This project uses GitHub Actions for continuous integration (CI) and Docker image management. There are two main workflows:
+
+   1. **Docker Publish Workflow** (`.github/workflows/docker-publish.yml`):  
+      This workflow builds the Docker image (`myndfirmware:latest`) and publishes it to the repository owner's GitHub Container Registry (GHCR).  
+      **You must run this workflow manually** (via the "Actions" tab and selecting "Build and Publish Docker Image for Mynd Build Env") whenever you update the Dockerfile or before running the build workflow for the first time.  
+      This ensures the latest build environment is available for CI.
+
+   2. **Build Workflow** (`.github/workflows/ci.yml`):  
+      This workflow runs automatically on pushes, pull requests, or can be triggered manually.  
+      It pulls the `myndfirmware:latest` image from GHCR to build the firmware and bootloader.  
+      **If the Docker image has not been published yet, the build workflow will fail.**  
+      Always make sure the Docker Publish workflow has completed successfully before running or relying on the build workflow.
+
+   **Summary:**  
+   - Run the Docker Publish workflow first to build and push the Docker image.
+   - Then, run the Build workflow to build and test the firmware using the published image.


### PR DESCRIPTION
- Expanded README.md to include detailed usage instructions for CI pipelines using GitHub Actions.
- Updated ci.yml to reference the repository owner for Docker image management.
- Introduced a new docker-publish.yml workflow for building and publishing the Docker image to GHCR.